### PR TITLE
Add fix for github metadata plugin

### DIFF
--- a/lib/elixir-toolkit-theme-plugins.rb
+++ b/lib/elixir-toolkit-theme-plugins.rb
@@ -5,3 +5,5 @@ require 'jekyll'
 require "elixir-toolkit-theme-plugins/version"
 require "elixir-toolkit-theme-plugins/tool_table_filter"
 require "elixir-toolkit-theme-plugins/tool_tag"
+
+require "elixir-toolkit-theme-plugins/github_metadata_fix"

--- a/lib/elixir-toolkit-theme-plugins/github_metadata_fix.rb
+++ b/lib/elixir-toolkit-theme-plugins/github_metadata_fix.rb
@@ -1,0 +1,20 @@
+module Jekyll
+  # Override jekyll-github-metadata plugin
+  module GitHubMetadata
+    module RepositoryFix
+      # Allow to override site.github.source.branch with envvar JEKYLL_BUILD_BRANCH
+      # Allow to override site.github.source.path with envvar JEKYLL_BASE_PATH
+
+      def source
+        {
+          "branch" => ENV["JEKYLL_BUILD_BRANCH"] ||  super["branch"],
+          "path" => ENV["JEKYLL_BASE_PATH"] || super["path"],
+        }
+      end
+    end
+
+    class Repository
+      prepend RepositoryFix
+    end
+  end
+end


### PR DESCRIPTION
This should allow to override `site.github.source.branch` and `site.github.source.path` provided by [`jekyll-github-metadata`](https://github.com/jekyll/github-metadata) plugin with environment variables `JEKYLL_BUILD_BRANCH` and `JEKYLL_BASE_PATH`.

- The naming of variables is based on the already available `JEKYLL_BUILD_REVISION` ([ref](https://github.com/jekyll/github-metadata/blob/v2.15.0/docs/configuration.md#overrides)).
- If `JEKYLL_BUILD_BRANCH` is not provided, it fallbacks to [this](https://github.com/jekyll/github-metadata/blob/v2.15.0/lib/jekyll-github-metadata/repository_compat.rb#L63). I wanted to retrieve the branch name using `git` (with `` `git rev-parse --abbrev-ref HEAD`.strip``, similarly to how it works for `JEKYLL_BUILD_REVISION` [here](https://github.com/jekyll/github-metadata/blob/v2.15.0/lib/jekyll-github-metadata/metadata_drop.rb#L91)) but that would break the compatibility with GitHub Pages without Actions...
- Similarly `JEKYLL_BASE_PATH` fallbacks to [this](https://github.com/jekyll/github-metadata/blob/v2.15.0/lib/jekyll-github-metadata/repository_compat.rb#L64).
- Not sure whether the `jekyll-github-metadata` should be directly dependency here... or in the theme. Currently it is neither here or there.

Alternatively, we could replace the `jekyll-github-metadata` entirely and get rid of a bit weird use of "site.github" (e.g. when used with GitLab or other) with a custom configuration that can be done via envvars, config YAML file, and `git` (based on what is currently used/needed in the theme):

- `site.github.repository_url` = envvar, fallback to YAML file (currently based on `PAGES_GITHUB_HOSTNAME` and `PAGES_REPO_NWO`), alternatively could be tried to compose based on `git config --get remote.origin.url` (`PAGES_REPO_NWO` could be replaced in a similar way)
- `site.github.source.branch` = envvar, fallback to `git rev-parse`
- `site.github.build_revision` = envvar, fallback to `git rev-parse`
- `site.github.url` = envvar, fallback to YAML file (currently retrieved via GitHub API which is nice for GitHub but not for others)
- ... I did not find others to be used from that plugin 🤷🏻‍♂️ 

The question is whether you still want to support GitHub Pages without GitHub Actions or not...