### PR TITLE
Use dropdowns instead of popovers

### DIFF
--- a/lib/elixir-toolkit-theme-plugins/tool_tag.rb
+++ b/lib/elixir-toolkit-theme-plugins/tool_tag.rb
@@ -17,20 +17,20 @@ module Jekyll
 
             def render(context)
                 tool = find_tool(context[@content.strip])
-                if tool["registry"]
-                    tags = create_tags(tool["registry"])
-                end
-                %Q{<a
-                    tabindex="0"
-                    class="tool"
-                    aria-description="#{tool["description"]}"
-                    data-bs-toggle="popover"
-                    data-bs-placement="bottom"
-                    data-bs-trigger="focus"
-                    data-bs-content="<h5>#{tool["name"]}</h5><div class='mb-2'>#{tool["description"]}</div><a href='#{tool["url"]}'target='_blank'><span class='badge bg-dark text-white hover-primary'><i class='fa-solid fa-link me-2'></i>Website</span></a>#{tags}"
-                    data-bs-template="<div class='popover popover-tool' role='tooltip'><div class='popover-arrow'></div><h3 class='popover-header'></h3><div class='popover-body'></div></div>"
-                    data-bs-html="true"
-                    ><i class="fa-solid fa-wrench me-2"></i>#{ tool["name"] }</a>}
+                tags = create_tags(tool)
+                %Q{#{"<div class='dropdown d-inline'>
+                    <a class='tool' type='button' aria-description='%{description}' data-bs-toggle='dropdown' data-bs-auto-close='outside'>
+                    <i class='fa-solid fa-wrench me-2'></i>%{name}</a>
+                    <div class='dropdown-menu shadow border-0'>
+                        <div class='card'>
+                            <div class='card-body'>
+                                <h5>%{name}</h5>
+                                <div class='mb-2'>%{description}</div>
+                                %{tags}
+                            </div>
+                        </div>
+                    </div>
+                </div>" % {name: tool["name"], description: tool["description"], tags: tags }}}
             end
 
             def find_tool(tool_id)
@@ -40,25 +40,28 @@ module Jekyll
                 raise Exception.new "Undefined tool ID: #{tool_id}"
             end
 
-            def create_tags(registry)
+            def create_tags(tool)
                 tags = ""
+                tags << create_tag("#{tool["url"]}", "fa-link", "Website")
+                if tool["registry"]
+                    registry = tool["registry"]
 
-                if registry["biotools"]
-                    tags << create_tag("https://bio.tools/#{registry["biotools"]}", "fa-info", "Tool info")
+                    if registry["biotools"]
+                        tags << create_tag("https://bio.tools/#{registry["biotools"]}", "fa-info", "Tool info")
+                    end
+
+                    if registry["fairsharing"]
+                        tags << create_tag("https://fairsharing.org/FAIRsharing.#{registry["fairsharing"]}", "fa-database", "Standards/Databases")
+                    end
+
+                    if registry["fairsharing-coll"]
+                        tags << create_tag("https://fairsharing.org/#{registry["fairsharing-coll"]}", "fa-database", "Standards/Databases")
+                    end
+
+                    if registry["tess"]
+                        tags << create_tag("https://tess.elixir-europe.org/search?q=#{registry["tess"]}", "fa-graduation-cap", "Training")
+                    end
                 end
-
-                if registry["fairsharing"]
-                    tags << create_tag("https://fairsharing.org/FAIRsharing.#{registry["fairsharing"]}", "fa-database", "Standards/Databases")
-                end
-
-                if registry["fairsharing-coll"]
-                    tags << create_tag("https://fairsharing.org/#{registry["fairsharing-coll"]}", "fa-database", "Standards/Databases")
-                end
-
-                if registry["tess"]
-                    tags << create_tag("https://tess.elixir-europe.org/search?q=#{registry["tess"]}", "fa-graduation-cap", "Training")
-                end
-
                 tags
             end
 


### PR DESCRIPTION
To make the popovers more accessible and clickable, it would be nice to use dropdowns. Problem is that they don't behave well inline paragraphs due to the nature of divs