### PR TITLE
Add support for repositories without pages dir

### DIFF
--- a/lib/elixir-toolkit-theme-plugins/tool_table_filter.rb
+++ b/lib/elixir-toolkit-theme-plugins/tool_table_filter.rb
@@ -20,14 +20,14 @@ module Jekyll
 
             def load_page_data
                 @related_pages = {}
-                pages_path = File.join(Dir.pwd, "pages", "**", "*.md")
+                pages_path = File.join(Dir.pwd, "**", "*.md")
                 Dir.glob(pages_path).each do |f|
                     file = File.read(f)
                     page_id_matches = file.match(/page_id:\s*(\w+)/)
                     
                     if page_id_matches
                         page_id = page_id_matches[1]
-                        file.scan(/\{% tool "([^"]+)" %}/).flatten.each do |m|
+                        file.scan(/\{%\s*tool\s*"([^"]+)"\s*%}/).flatten.each do |m|
                             @related_pages[m] = Set[] unless @related_pages[m]
                             @related_pages[m].add(page_id)
                         end

--- a/lib/elixir-toolkit-theme-plugins/version.rb
+++ b/lib/elixir-toolkit-theme-plugins/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
     class Ett
-      VERSION = '0.1.7'
+      VERSION = '0.1.8'
     end
   end


### PR DESCRIPTION
Currently, markdown pages had to be located in the `/pages` directory. After this pull request, this will not be needed anymore. 
Other improvement: less picky when it comes to spaces surrounding the tool tag in the snippet